### PR TITLE
Add incoming call switch.

### DIFF
--- a/ge1mer/domofon.yaml
+++ b/ge1mer/domofon.yaml
@@ -33,8 +33,8 @@ substitutions:
   api_password: "esphome"
 
   # Software configuration
-  call_end_detect_delay: 3000ms     # Interval between rings to detect incoming call
-  relay_before_answer_delay: 400ms  # Delay before answer call
+  call_delay: 500ms     # Interval rings
+  call_end_detect_delay: 5000ms     #  Interval between rings to detect incoming call
   relay_answer_on_time: 1000ms      # Delay between answer call and open/close door
   relay_open_on_time: 300ms         # How long the "open door button" will be pressed
   relay_after_open_delay: 500ms     # Delay in "answer" state after opening door

--- a/ge1mer/domofon.yaml
+++ b/ge1mer/domofon.yaml
@@ -35,7 +35,7 @@ substitutions:
   # Software configuration
   call_delay: 500ms     # Interval rings
   call_end_detect_delay: 5000ms     #  Interval between rings to detect incoming call
-  relay_before_answer_delay: 400ms
+  relay_before_answer_delay: 400ms  # Delay before answer call
   relay_answer_on_time: 1000ms      # Delay between answer call and open/close door
   relay_open_on_time: 300ms         # How long the "open door button" will be pressed
   relay_after_open_delay: 500ms     # Delay in "answer" state after opening door

--- a/ge1mer/domofon.yaml
+++ b/ge1mer/domofon.yaml
@@ -35,6 +35,7 @@ substitutions:
   # Software configuration
   call_delay: 500ms     # Interval rings
   call_end_detect_delay: 5000ms     #  Interval between rings to detect incoming call
+  relay_before_answer_delay: 400ms
   relay_answer_on_time: 1000ms      # Delay between answer call and open/close door
   relay_open_on_time: 300ms         # How long the "open door button" will be pressed
   relay_after_open_delay: 500ms     # Delay in "answer" state after opening door

--- a/ge1mer/domofon_packages/base.yaml
+++ b/ge1mer/domofon_packages/base.yaml
@@ -50,6 +50,16 @@ globals:
     type: bool
     restore_value: yes
     initial_value: 'false'
+  - id: incoming_call
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+    
+text_sensor:
+  - platform: template
+    name: "${board_name} Uptime"
+    id: uptime_human
+    icon: mdi:clock-start
 
 sensor:
   - platform: template
@@ -58,32 +68,28 @@ sensor:
     update_interval: 20s
     unit_of_measurement: bytes
     accuracy_decimals: 0
+    
   - platform: uptime
-    internal: true
+    name: Uptime Sensor
     id: uptime_sensor
-
-text_sensor:
-  - platform: template
-    name: "${board_name} Uptime"
-    lambda: |-
-      uint32_t dur = id(uptime_sensor).state;
-      int dys = 0;
-      int hrs = 0;
-      int mnts = 0;
-      if (dur > 86399) {
-        dys = trunc(dur / 86400);
-        dur = dur - (dys * 86400);
-      }
-      if (dur > 3599) {
-        hrs = trunc(dur / 3600);
-        dur = dur - (hrs * 3600);
-      }
-      if (dur > 59) {
-        mnts = trunc(dur / 60);
-        dur = dur - (mnts * 60);
-      }
-      char buffer[17];
-      sprintf(buffer, "%ud %02uh %02um %02us", dys, hrs, mnts, dur);
-      return {buffer};
-    icon: mdi:clock-start
     update_interval: 60s
+    internal: True
+    on_raw_value:
+      then:
+        - text_sensor.template.publish:
+            id: uptime_human
+            state: !lambda |-
+              int seconds = round(id(uptime_sensor).raw_state);
+              int days = seconds / (24 * 3600);
+              seconds = seconds % (24 * 3600);
+              int hours = seconds / 3600;
+              seconds = seconds % 3600;
+              int minutes = seconds /  60;
+              seconds = seconds % 60;
+              return (
+                (days ? String(days) + "d " : "") +
+                (hours ? String(hours) + "h " : "") +
+                (minutes ? String(minutes) + "m " : "") +
+                (String(seconds) + "s")
+              ).c_str();
+ 

--- a/ge1mer/domofon_packages/binary_sensor.yaml
+++ b/ge1mer/domofon_packages/binary_sensor.yaml
@@ -1,21 +1,27 @@
 binary_sensor:
   # Call detection
   - platform: gpio
-    name: "${board_name} incoming call"
-    id: incoming_call
+    name: "${board_name} incoming sensor"
+    id: incoming_sensor
     device_class: sound
+    internal: True
     pin:
       number: $pin_call_detect
       mode: INPUT_PULLUP
       inverted: True
     filters:
-      delayed_off: $call_end_detect_delay
+      delayed_off: $call_delay
     on_press:
       then:
-        script.execute: state_call
+        if:
+          condition:
+               switch.is_off: incoming_switch
+          then:
+             - script.execute: state_call                
     on_release:
       then:
-        script.execute: state_no_call
+            - script.stop: stop_call
+            - script.execute: stop_call
 
   # Accept HW button
   - platform: gpio
@@ -34,7 +40,7 @@ binary_sensor:
         then:
           if:
             condition:
-              binary_sensor.is_on: incoming_call
+              switch.is_on: incoming_switch
             then:
               script.execute: call_accept
             else:
@@ -58,7 +64,7 @@ binary_sensor:
         then:
           if:
             condition:
-              binary_sensor.is_on: incoming_call
+              switch.is_on: incoming_switch
             then:
               script.execute: call_reject
             else:

--- a/ge1mer/domofon_packages/script.yaml
+++ b/ge1mer/domofon_packages/script.yaml
@@ -30,7 +30,6 @@ script:
   - id: call_accept
     then:
       - logger.log: "Accept call"
-     
       - delay: $relay_before_answer_delay
       - script.execute: state_answer
       - delay: $relay_answer_on_time

--- a/ge1mer/domofon_packages/script.yaml
+++ b/ge1mer/domofon_packages/script.yaml
@@ -30,7 +30,7 @@ script:
   - id: call_accept
     then:
       - logger.log: "Accept call"
-      - script.execute: state_no_call
+     
       - delay: $relay_before_answer_delay
       - script.execute: state_answer
       - delay: $relay_answer_on_time
@@ -39,6 +39,7 @@ script:
       - script.execute: state_answer
       - delay: $relay_after_open_delay
       - script.execute: state_ready
+      - script.execute: state_no_call
       - globals.set:
           id: mode_mute_once
           value: 'false'
@@ -47,11 +48,11 @@ script:
   - id: call_reject
     then:
       - logger.log: "Reject call"
-      - script.execute: state_no_call
       - delay: $relay_before_answer_delay
       - script.execute: state_answer
       - delay: $relay_answer_on_time
       - script.execute: state_ready
+      - script.execute: state_no_call
       - globals.set:
           id: mode_mute_once
           value: 'false'
@@ -59,7 +60,10 @@ script:
   # No call state
   - id: state_no_call
     then:
-      - logger.log: "Set state 'No call'"
+             - globals.set:
+                id: incoming_call
+                value: 'false'
+             - script.stop: stop_call
       - lambda: |-
           if (id(mode_auto_open_once)) {
             id(led_blink_green_1_on).execute();
@@ -72,11 +76,24 @@ script:
           } else {
             id(led_off).execute();
           }
+          
+  # Stop call 
+  - id: stop_call
+    then:
+       - delay: $call_end_detect_delay
+       - if:
+           condition:
+               binary_sensor.is_off: incoming_sensor
+           then:
+               - script.execute: state_no_call
 
   # Call state
   - id: state_call
     then:
       - logger.log: "Set state 'Incoming call'"
+      - globals.set:
+           id: incoming_call
+           value: 'true'
       - lambda: |-
           if (id(mode_auto_reject)) {
             id(call_reject).execute();

--- a/ge1mer/domofon_packages/switch.yaml
+++ b/ge1mer/domofon_packages/switch.yaml
@@ -142,7 +142,7 @@ switch:
     turn_on_action:
       if:
         condition:
-          binary_sensor.is_on: incoming_call
+          switch.is_on: incoming_switch
         then:
           script.execute: call_accept
         else:
@@ -156,8 +156,16 @@ switch:
     turn_on_action:
       if:
         condition:
-          binary_sensor.is_on: incoming_call
+          switch.is_on: incoming_switch
         then:
           script.execute: call_reject
         else:
           logger.log: "No incoming call"
+          
+   # Incoming call
+  - platform: template
+    name: "${board_name} incoming call"
+    id: incoming_switch
+    icon: "mdi:door-closed-lock"
+    lambda: |-
+      return id(incoming_call);


### PR DESCRIPTION
Добавил прослойку для бинарного сенсора. Чтобы, можно было отбивать программно вызов после принятия или отклонения вызова. Теперь задержка call_end_detect_delay сильно не влияет на результат, главное чтобы она был не сильно короткой. Теперь постоянное отклонение и принятие вызова работает адекватно, даже если быстро совершать вызов.
Заменил аптайм скрипт. Взял из официального примера. Прошлый у меня как-то странно глючил.
Возможно,  incoming call switch нужно заменить на что-то другое, но в esphome мало вариантов.
Надеюсь внес все изменения. На своем домофоне проверил, все работает.